### PR TITLE
[View] change `getTextBounds` to `measureText`

### DIFF
--- a/readmore-view/src/main/java/com/webtoonscorp/android/readmore/ReadMoreTextView.kt
+++ b/readmore-view/src/main/java/com/webtoonscorp/android/readmore/ReadMoreTextView.kt
@@ -19,7 +19,6 @@ import android.annotation.SuppressLint
 import android.content.Context
 import android.content.res.ColorStateList
 import android.content.res.TypedArray
-import android.graphics.Rect
 import android.graphics.Typeface
 import android.text.Layout
 import android.text.TextPaint
@@ -327,13 +326,12 @@ public class ReadMoreTextView @JvmOverloads constructor(
     private fun CharSequence.calculateReplaceCountToBeSingleLineWith(
         maximumTextWidth: Int
     ): Int {
-        val currentTextBounds = Rect()
+        var replacedTextWidth: Float
         var replacedCount = -1
         do {
             replacedCount++
-            val replacedText = substring(0, this.length - replacedCount)
-            paint.getTextBounds(replacedText, 0, replacedText.length, currentTextBounds)
-        } while (replacedCount < this.length && currentTextBounds.width() >= maximumTextWidth)
+            replacedTextWidth = paint.measureText(substring(0, this.length - replacedCount))
+        } while (replacedCount < this.length && replacedTextWidth >= maximumTextWidth)
 
         val lastVisibleChar: Char? = this.getOrNull(this.length - replacedCount - 1)
         val firstOverflowChar: Char? = this.getOrNull(this.length - replacedCount)


### PR DESCRIPTION
- close #26 
- `measureText`function include bounds start and end.
- It is recommended to use `measureText` rather than `getTextBounds` to calculate including bounds.

| `currentTextBounds` | `measureText` |
| --- | --- |
| <img width="691" alt="스크린샷 2022-11-01 오전 10 14 46" src="https://user-images.githubusercontent.com/14272430/199142405-1cb6ffd8-c994-468a-a933-4b63c6498c81.png"> | <img width="668" alt="image" src="https://user-images.githubusercontent.com/14272430/199144918-24974b59-7849-4680-b124-12c85dabcad2.png"> |
| <img width="177" alt="스크린샷 2022-11-01 오전 10 13 50" src="https://user-images.githubusercontent.com/14272430/199142388-89367835-62aa-478d-9b95-db5a585f3dbb.png"> | <img width="192" alt="스크린샷 2022-11-01 오전 10 13 54" src="https://user-images.githubusercontent.com/14272430/199142393-58316e8f-a436-4dcc-b082-87f616cf7fc1.png"> |

- referred: https://stackoverflow.com/a/7579469