### PR TITLE
Fix that readLessTextSize attribute is not working for ReadMoreTextView

### DIFF
--- a/readmore-view/src/main/java/com/webtoonscorp/android/readmore/ReadMoreTextView.kt
+++ b/readmore-view/src/main/java/com/webtoonscorp/android/readmore/ReadMoreTextView.kt
@@ -501,9 +501,9 @@ public class ReadMoreTextView @JvmOverloads constructor(
                         ?: it.getFontFamilyFromTypeface(AppCompatR.styleable.TextAppearance_android_typeface)
             }
         }
-        if (ta.hasValue(R.styleable.ReadMoreTextView_readLessTextUnderline)) {
+        if (ta.hasValue(R.styleable.ReadMoreTextView_readLessTextSize)) {
             textSize = ta.getDimensionPixelSize(
-                R.styleable.ReadMoreTextView_readLessTextUnderline,
+                R.styleable.ReadMoreTextView_readLessTextSize,
                 DEFAULT_TEXT_SIZE
             )
         }


### PR DESCRIPTION
**Code Example:**
```xml
app:readLessTextSize="11sp"
```

Before | After
-- | --
<img width="300" src="https://user-images.githubusercontent.com/3405740/218789158-080f77f5-4364-4c47-b85e-65c0291d9162.png" /> | <img width="300" src="https://user-images.githubusercontent.com/3405740/218789149-aed08fa6-c026-44a2-9d04-01b26247a9d3.png" />
