### PR TITLE
Fix bug where 'more' text would consume click events when `onExpandedChange` is not set and `toggleArea` is 'More'

### DIFF
--- a/readmore-foundation/src/main/java/com/webtoonscorp/android/readmore/foundation/BasicReadMoreText.kt
+++ b/readmore-foundation/src/main/java/com/webtoonscorp/android/readmore/foundation/BasicReadMoreText.kt
@@ -249,11 +249,15 @@ private fun CoreReadMoreText(
             append(text)
             if (readLessTextWithStyle.isNotEmpty()) {
                 append(' ')
-                withLink(
-                    LinkAnnotation.Clickable(tag = ReadLessTag) {
-                        onExpandedChange?.invoke(false)
-                    },
-                ) {
+                if (toggleArea == ToggleArea.More) {
+                    withLink(
+                        LinkAnnotation.Clickable(tag = ReadLessTag) {
+                            onExpandedChange?.invoke(false)
+                        },
+                    ) {
+                        append(readLessTextWithStyle)
+                    }
+                } else {
                     append(readLessTextWithStyle)
                 }
             }
@@ -263,11 +267,15 @@ private fun CoreReadMoreText(
                 append(collapsedText)
                 append(overflowText)
 
-                withLink(
-                    LinkAnnotation.Clickable(tag = ReadMoreTag) {
-                        onExpandedChange?.invoke(true)
-                    },
-                ) {
+                if (toggleArea == ToggleArea.More) {
+                    withLink(
+                        LinkAnnotation.Clickable(tag = ReadMoreTag) {
+                            onExpandedChange?.invoke(true)
+                        },
+                    ) {
+                        append(readMoreTextWithStyle)
+                    }
+                } else {
                     append(readMoreTextWithStyle)
                 }
             } else {


### PR DESCRIPTION

| Before | After |
| -- | -- |
| <video width="300" src="https://github.com/user-attachments/assets/72ef3814-8399-4f64-b907-c931dd4f1fec" /> | <video width="300" src="https://github.com/user-attachments/assets/76ce9da2-6214-4370-a68b-b99eb730ea23" /> |
