### PR TITLE
Update ktlint from 0.49.0 to 0.49.1

### DIFF
--- a/gradle/init.gradle.kts
+++ b/gradle/init.gradle.kts
@@ -1,4 +1,4 @@
-val ktlintVersion = "0.49.0"
+val ktlintVersion = "0.49.1"
 
 initscript {
     val spotlessVersion = "6.22.0"


### PR DESCRIPTION
Fixes `NullPointerException` in `standard:indent` rule ([ktlint#1993](https://github.com/pinterest/ktlint/issues/1993)) that crashes on certain inline function + extension receiver lambda combinations. This unblocks #111.